### PR TITLE
Specify types file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.4",
   "description": "Asynchronous batched iterable for (mongo) cursors",
   "main": "index.js",
-  "types": "./lib/batch-mobile.d.ts",
+  "types": "./lib/batched-cursor.d.ts",
   "scripts": {
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.4",
   "description": "Asynchronous batched iterable for (mongo) cursors",
   "main": "index.js",
+  "types": "./lib/batch-mobile.d.ts",
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
NPM uses the "types" key in package.json to show the TS symbol next to package name.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html